### PR TITLE
Bugfix/Accessibility: Add focus styles back in

### DIFF
--- a/css/_common.scss
+++ b/css/_common.scss
@@ -1,8 +1,34 @@
 @import "vars";
 @import "syntax-highlighting";
 
-* {
+/* Styles where only focus is supported */
+*:focus {
+  /* Fallback if no custom properties */
+  outline: 2px solid currentColor;
+  /* 
+    The focus color will have to vary based on the background color.
+    We set currentColor as the default, as a good guess, and override with --focus-color otherwise.
+    For example, buttons with a black background and white text, on a white background page, will need a custom color.
+  */
+  outline: 2px solid var(--focus-color, currentColor);
+  /* Give some room for buttons */
+  outline-offset: 2px;
+}
+
+/* 
+  Reset styles where focus-visible matches
+  (we'll add them back in the next block)
+*/
+*:focus:not(:focus-visible) {
   outline: none;
+}
+
+/* 
+  The final, :focus-visible styles. 
+  You could elect to make these even more obvious.
+*/
+*:focus-visible {
+  outline: 2px solid var(--focus-color, currentColor);
 }
 
 body {
@@ -36,6 +62,8 @@ a.btn {
   line-height: 1;
 
   &.black {
+    /* A better default for focus colour on white backgrounds */
+    --focus-color: #{$btn-bg-black};
     background: $btn-bg-black;
     border: $btn-border-black;
     color: $btn-color-black;


### PR DESCRIPTION
Hi! I ran into the hypercore website, and I noticed that focus styles were hidden with a blanket `outline: none` rule.
This rule is detrimental to accessibility, for example for keyboard users.

This PR adds focus styles back in, with a layered approach:
- currentColor is used as the default focus color, with some spacing
- A custom property, --focus-color, is used to override the color, for example to make focus visible for black buttons on white backgrounds
- The :focus-visible selector is used where supported, to only show outlines only for modalities and users that need them
- The :focus selector is used as a fallback where :focus-visible is not supported, to cause no harm to users on those browsers

I would like to not debate whether accessibility matters, but I'm happy to make changes to the PR if they fit the code style or other reasons better :)  For example, I left comments in the code to help the next person, but maybe some of them are redundant or can be clarified?

If this PR looks good, I'm also happy to open PRs for other fixes (reduced motion, link styling, text alternatives, keyboard operation of menus). I believe accessibility is very much in the spirit of hypercore and the site!